### PR TITLE
feat: add link and environment support to aws.Auth

### DIFF
--- a/platform/src/components/aws/auth.ts
+++ b/platform/src/components/aws/auth.ts
@@ -2,6 +2,8 @@ import {
   ComponentResourceOptions,
   jsonStringify,
   Output,
+  output,
+  all,
 } from "@pulumi/pulumi";
 import { Component } from "../component";
 import { Link } from "../link";
@@ -10,6 +12,7 @@ import { functionBuilder } from "./helpers/function-builder";
 import { env } from "../linkable";
 import { Auth as AuthV1 } from "./auth-v1";
 import { Input } from "../input";
+import { Permission } from "./permission";
 
 export interface AuthArgs {
   /**
@@ -79,6 +82,47 @@ export interface AuthArgs {
    * the `issuer` function.
    */
   issuer?: Input<string | FunctionArgs>;
+  /**
+   * [Link resources](/docs/linking/) to your Auth issuer function. This will:
+   *
+   * 1. Grant the permissions needed to access the resources.
+   * 2. Allow you to access it in your function using the [SDK](/docs/reference/sdk/).
+   *
+   * @example
+   *
+   * Takes a list of components to link to the issuer function.
+   *
+   * ```js
+   * {
+   *   link: [bucket, stripeKey]
+   * }
+   * ```
+   */
+  link?: Input<any[]>;
+  /**
+   * Key-value pairs that are made available to the issuer function as environment
+   * variables. The keys need to:
+   * - Start with a letter
+   * - Be at least 2 characters long
+   * - Contain only letters, numbers, or underscores
+   *
+   * They can be accessed in your function using `process.env.<key>`.
+   *
+   * :::note
+   * The total size of the environment variables cannot exceed 4 KB.
+   * :::
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   environment: {
+   *     DEBUG: "true"
+   *   }
+   * }
+   * ```
+   */
+  environment?: Input<Record<string, Input<string>>>;
   /**
    * Set a custom domain for your Auth server.
    *
@@ -194,6 +238,73 @@ export interface AuthArgs {
  *   domain: "auth.example.com"
  * });
  * ```
+ * 
+ * #### Customize theme with assets
+ * 
+ * You can link a bucket to store and serve assets for your auth UI theme, like logos.
+ * 
+ * ```ts title="sst.config.ts"
+ * // Create a bucket for assets
+ * const bucket = new sst.aws.Bucket("Assets", {
+ *   cors: true,
+ *   cdk: {
+ *     bucket: {
+ *       publicReadAccess: true
+ *     }
+ *   }
+ * });
+ * 
+ * // Link the bucket to Auth
+ * new sst.aws.Auth("MyAuth", {
+ *   issuer: "src/auth.handler",
+ *   link: [bucket]
+ * });
+ * ```
+ * 
+ * Then in your issuer function, you can use the bucket URL for assets in your theme:
+ * 
+ * ```ts title="src/auth.ts"
+ * import { Resource } from "sst";
+ * 
+ * const app = issuer({
+ *   subjects,
+ *   theme: {
+ *     title: "My App",
+ *     // Use the bucket URL for the logo
+ *     logo: {
+ *       light: `${Resource.Assets.url}/logo-light.svg`,
+ *       dark: `${Resource.Assets.url}/logo-dark.svg`
+ *     },
+ *     // ... other theme options
+ *   },
+ *   // ... other options
+ * });
+ * ```
+ *
+ * #### Link resources to Auth
+ *
+ * You can link resources to your Auth component. This allows the issuer function
+ * to access these resources.
+ *
+ * ```ts title="sst.config.ts" {3}
+ * new sst.aws.Auth("MyAuth", {
+ *   issuer: "src/auth.handler",
+ *   link: [bucket, stripeKey]
+ * });
+ * ```
+ *
+ * #### Set environment variables
+ *
+ * You can set environment variables for the issuer function.
+ *
+ * ```ts title="sst.config.ts" {3-5}
+ * new sst.aws.Auth("MyAuth", {
+ *   issuer: "src/auth.handler",
+ *   environment: {
+ *     STRIPE_SECRET_KEY: "sk_test_123"
+ *   }
+ * });
+ * ```
  *
  * #### Link to a resource
  *
@@ -278,17 +389,23 @@ export class Auth extends Component implements Link.Linkable {
     function createIssuer() {
       const fn = args.authorizer || args.issuer;
       if (!fn) throw new Error("Auth: issuer field must be set");
+
+      const linkData = output(args.link || []).apply((links: any[]) => Link.build(links));
+      const linkPermissions = Link.getInclude<Permission>("aws.permission", args.link);
+
       return functionBuilder(
         `${name}Issuer`,
         fn,
         {
-          link: [table],
-          environment: {
+          link: all([args.link, table]).apply(([link, table]) => [table, ...(link || [])]),
+          environment: all([args.environment]).apply(([environment]) => ({
             OPENAUTH_STORAGE: jsonStringify({
               type: "dynamo",
               options: { table: table.name },
             }),
-          },
+            ...(environment ?? {}),
+          })),
+          permissions: linkPermissions,
           _skipHint: true,
         },
         (args) => {
@@ -297,7 +414,7 @@ export class Auth extends Component implements Link.Linkable {
           };
         },
         { parent: self },
-      ).apply((v) => v.getFunction());
+      ).apply(v => v.getFunction());
     }
 
     function createRouter() {


### PR DESCRIPTION
## Summary
Adds link and environment support to sst.aws.Auth. For transparency, I haven’t worked in the SST codebase before, and this code was generated by Claude. I do believe there’s a real need to be able to pass links to the Auth component. Unless I'm overlooking a simple way to achieve this.

I haven’t tested these changes yet, but I plan to do so soon. I’m not currently set up to run SST locally and need to step away for now. This seems like a straightforward change, but since I’m not very familiar with SST, I’m sure there are some small decisions here that I might not have gotten quite right. If someone more familiar with the library is able to implement this properly, I’d really appreciate it.

## Use Case
Setting logo url based on my static site deployed to a CDN. I don't want to worry about hosting my logo somewhere when I already have the static site on a CDN.

**Before** (manual hardcoding / linking not allowed):
```ts
export const auth = new sst.aws.Auth("Auth", {
  issuer: "packages/auth/src/index.handler",
});
```

**After** (dynamic linking):
```ts
export const auth = new sst.aws.Auth("Auth", {
  issuer: "packages/auth/src/index.handler",
  link: [frontend] // Link frontend to access its URL
});
```

**In issuer function:**
```ts
const CUSTOM_THEME: Theme = {
  logo: `${Resource.Frontend.url}/logos/logo.svg`, // Dynamic URL
};
```

This enables hosting auth assets on the same efficient CDN as my SPA. I believe users could easily link buckets hosting their assets as well although a CDN seems preferable.

## Changes
- Added `link` parameter to `AuthArgs` interface with proper TypeScript documentation
- Added `environment` parameter to `AuthArgs` interface for custom environment variables  
- Updated issuer function creation to handle linked resources and custom environment
- Added comprehensive JSDoc examples showing asset hosting use case

🤖 Generated with [Claude Code](https://claude.ai/code)